### PR TITLE
Fix sass compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 .vscode
 .env
 *.css
+*.css.map

--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -1,3 +1,5 @@
+import os
+
 from flask import Flask
 from flask_assets import Bundle, Environment
 from flask_session import Session
@@ -13,8 +15,11 @@ assets = Environment(app)
 assets.url = app.static_url_path
 
 # Compile SCSS file
-css = compile_file("app/static/css/main.scss", dest="app/static/css/main.css") # todo maybe deactivate source map generation in prod
-css_bundle = Bundle("css/main.scss")
+compile_file(
+    os.path.join(app.static_folder, "css/main.scss"),
+    dest=os.path.join(app.static_folder, "css/main.css")
+)  # todo maybe deactivate source map generation in prod
+css_bundle = Bundle("css/main.css")
 assets.register("scss_all", css_bundle)
 
 Session(app)

--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -17,7 +17,7 @@ assets.url = app.static_url_path
 # Compile SCSS file
 compile_file(
     os.path.join(app.static_folder, "css/main.scss"),
-    dest=os.path.join(app.static_folder, "css/main.css")
+    dest=os.path.join(app.static_folder, "css/main.css"),
 )  # todo maybe deactivate source map generation in prod
 css_bundle = Bundle("css/main.css")
 assets.register("scss_all", css_bundle)

--- a/flask/app/__init__.py
+++ b/flask/app/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask
 from flask_assets import Bundle, Environment
 from flask_session import Session
 from flask_sqlalchemy import SQLAlchemy
+from sass_embedded import compile_file
 
 from . import settings
 
@@ -10,8 +11,11 @@ app.config.from_object(settings)
 
 assets = Environment(app)
 assets.url = app.static_url_path
-scss = Bundle("css/main.scss", filters="pyscss", output="css/main.css")
-assets.register("scss_all", scss)
+
+# Compile SCSS file
+css = compile_file("app/static/css/main.scss", dest="app/static/css/main.css") # todo maybe deactivate source map generation in prod
+css_bundle = Bundle("css/main.scss")
+assets.register("scss_all", css_bundle)
 
 Session(app)
 

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -7,7 +7,7 @@ Flask==3.1.1
 Flask-Session==0.8.0
 Flask-SQLAlchemy==3.1.1
 Flask-Assets==2.1.0
-pyScss==1.4.0
+sass-embedded==0.1.2
 spotipy==2.25.1
 beautifulsoup4==4.13.4
 wikipedia==1.4.0


### PR DESCRIPTION
do not use pyScss / libsass because they are deprecated. There is no official python wrapper by the sass team, but there is an official cli tool called sass. The python lib sass-embedded makes use of this cli tool